### PR TITLE
Trigger new Linux build 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:


### PR DESCRIPTION
No Linux packages for python 3.7 have been build before https://anaconda.org/conda-forge/bcrypt/files 